### PR TITLE
Re-enabled FPAS for China

### DIFF
--- a/app/src/main/java/org/breezyweather/sources/fpas/FpasService.kt
+++ b/app/src/main/java/org/breezyweather/sources/fpas/FpasService.kt
@@ -67,14 +67,6 @@ class FpasService @Inject constructor(
         name to "https://invent.kde.org/webapps/foss-public-alert-server/"
     )
 
-    // Disabled for China
-    override fun isFeatureSupportedForLocation(
-        location: Location,
-        feature: SourceFeature,
-    ): Boolean {
-        return !location.countryCode.equals("CN", ignoreCase = true)
-    }
-
     override fun requestWeather(
         context: Context,
         location: Location,


### PR DESCRIPTION
FPAS has deployed their [fix](https://invent.kde.org/webapps/foss-public-alert-server/-/commit/510297b84cfbef53b290fa641ebfd35f23667c93) to enable dissemination of CAP Alerts in China, so we can re-enable FPAS for China also.